### PR TITLE
Add db healthcheck for app dependency

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -6,7 +6,8 @@ services:
     volumes:
       - .:/app
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - "8080:8080"
     environment:
@@ -14,6 +15,11 @@ services:
   db:
     container_name: db
     image: "postgres:14.0-alpine"
+    healthcheck:
+      test: pg_isready
+      interval: 5s
+      timeout: 10s
+      retries: 10
     ports:
       - "5432:5432"
     environment:


### PR DESCRIPTION
Adds a quick health check on the Postgres container to ensure the database is ready to accept connections before the application starts. 

This PR will help people avoid confusion if they pull down the project fresh for testing and the app exits due to the database waiting to accept connections. I am using the `pg_isready` command built into the Postgres container to test if the container is ready for outside connections.