### PR TITLE
refactor: add query builder for by/with name on tag

### DIFF
--- a/src/app/article/model.rs
+++ b/src/app/article/model.rs
@@ -121,12 +121,10 @@ impl Article {
     }
 
     pub fn delete(conn: &mut PgConnection, params: &DeleteArticle) -> Result<(), AppError> {
-        diesel::delete(
-            articles::table
-                .filter(Self::with_slug(&params.slug))
-                .filter(Self::with_author_id(&params.author_id)),
-        )
-        .execute(conn)?;
+        let t = articles::table
+            .filter(Self::with_slug(&params.slug))
+            .filter(Self::with_author_id(&params.author_id));
+        diesel::delete(t).execute(conn)?;
         // NOTE: references tag rows are deleted automatically by DELETE CASCADE
 
         Ok(())

--- a/src/app/article/model.rs
+++ b/src/app/article/model.rs
@@ -1,3 +1,4 @@
+use crate::app::favorite::model::Favorite;
 use crate::app::user::model::User;
 use crate::error::AppError;
 use crate::schema::articles;
@@ -141,8 +142,8 @@ impl Article {
         use crate::schema::favorites;
         let count = favorites::table
             .select(diesel::dsl::count(favorites::id))
-            .filter(favorites::article_id.eq_all(self.id))
-            .filter(favorites::user_id.eq_all(user_id))
+            .filter(Favorite::with_article_id(&self.id))
+            .filter(Favorite::with_user_id(user_id))
             .first::<i64>(conn)?;
 
         Ok(count >= 1)
@@ -151,7 +152,7 @@ impl Article {
     pub fn fetch_favorites_count(&self, conn: &mut PgConnection) -> Result<i64, AppError> {
         use crate::schema::favorites;
         let favorites_count = favorites::table
-            .filter(favorites::article_id.eq_all(self.id))
+            .filter(Favorite::with_article_id(&self.id))
             .select(diesel::dsl::count(favorites::created_at))
             .first::<i64>(conn)?;
         Ok(favorites_count)

--- a/src/app/article/model.rs
+++ b/src/app/article/model.rs
@@ -3,7 +3,8 @@ use crate::error::AppError;
 use crate::schema::articles;
 use crate::utils::converter;
 use chrono::NaiveDateTime;
-use diesel::dsl::{AsSelect, Eq, Filter, Select};
+// use diesel::dsl::{AsSelect, Eq, Filter, Select};
+use diesel::dsl::Eq;
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use diesel::Insertable;
@@ -24,9 +25,10 @@ pub struct Article {
     pub updated_at: NaiveDateTime,
 }
 
-type All<DB> = Select<articles::table, AsSelect<Article, DB>>;
+// type All<DB> = Select<articles::table, AsSelect<Article, DB>>;
 type WithAuthorId<T> = Eq<articles::author_id, T>;
 type WithSlug<T> = Eq<articles::slug, T>;
+type WithId<T> = Eq<articles::id, T>;
 // type ByArticleId<T, DB> = Filter<All<DB>, WithArticleId<T>>;
 
 impl Article {
@@ -36,6 +38,10 @@ impl Article {
 
     fn with_slug(slug: &str) -> WithSlug<&str> {
         articles::slug.eq(slug)
+    }
+
+    fn with_id(id: &Uuid) -> WithId<&Uuid> {
+        articles::id.eq(id)
     }
 }
 
@@ -108,7 +114,7 @@ impl Article {
         use crate::schema::users;
         let result = articles::table
             .inner_join(users::table)
-            .filter(articles::id.eq(id))
+            .filter(Self::with_id(id))
             .get_result::<(Article, User)>(conn)?;
         Ok(result)
     }

--- a/src/app/article/model.rs
+++ b/src/app/article/model.rs
@@ -4,7 +4,6 @@ use crate::error::AppError;
 use crate::schema::articles;
 use crate::utils::converter;
 use chrono::NaiveDateTime;
-// use diesel::dsl::{AsSelect, Eq, Filter, Select};
 use diesel::dsl::Eq;
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
@@ -26,11 +25,9 @@ pub struct Article {
     pub updated_at: NaiveDateTime,
 }
 
-// type All<DB> = Select<articles::table, AsSelect<Article, DB>>;
 type WithAuthorId<T> = Eq<articles::author_id, T>;
 type WithSlug<T> = Eq<articles::slug, T>;
 type WithId<T> = Eq<articles::id, T>;
-// type ByArticleId<T, DB> = Filter<All<DB>, WithArticleId<T>>;
 
 impl Article {
     fn with_author_id(author_id: &Uuid) -> WithAuthorId<&Uuid> {
@@ -61,13 +58,10 @@ impl Article {
         author_id: &Uuid,
         record: &UpdateArticle,
     ) -> Result<Self, AppError> {
-        let article = diesel::update(
-            articles::table
-                .filter(Self::with_slug(article_title_slug))
-                .filter(Self::with_author_id(author_id)),
-        )
-        .set(record)
-        .get_result::<Article>(conn)?;
+        let t = articles::table
+            .filter(Self::with_slug(article_title_slug))
+            .filter(Self::with_author_id(author_id));
+        let article = diesel::update(t).set(record).get_result::<Article>(conn)?;
         Ok(article)
     }
 
@@ -79,10 +73,10 @@ impl Article {
         conn: &mut PgConnection,
         params: &FetchBySlugAndAuthorId,
     ) -> Result<Self, AppError> {
-        let item = articles::table
+        let t = articles::table
             .filter(Self::with_slug(&params.slug))
-            .filter(Self::with_author_id(&params.author_id))
-            .first::<Self>(conn)?;
+            .filter(Self::with_author_id(&params.author_id));
+        let item = t.first::<Self>(conn)?;
         Ok(item)
     }
 
@@ -91,10 +85,10 @@ impl Article {
         slug: &str,
     ) -> Result<(Self, User), AppError> {
         use crate::schema::users;
-        let result = articles::table
+        let t = articles::table
             .inner_join(users::table)
-            .filter(Self::with_slug(slug))
-            .get_result::<(Self, User)>(conn)?;
+            .filter(Self::with_slug(slug));
+        let result = t.get_result::<(Self, User)>(conn)?;
         Ok(result)
     }
 
@@ -103,20 +97,20 @@ impl Article {
         name: &str,
     ) -> Result<Vec<Uuid>, AppError> {
         use crate::schema::users;
-        let ids = users::table
+        let t = users::table
             .inner_join(articles::table)
             .filter(User::with_username(name))
-            .select(articles::id)
-            .load::<Uuid>(conn)?;
+            .select(articles::id);
+        let ids = t.load::<Uuid>(conn)?;
         Ok(ids)
     }
 
     pub fn find_with_author(conn: &mut PgConnection, id: &Uuid) -> Result<(Self, User), AppError> {
         use crate::schema::users;
-        let result = articles::table
+        let t = articles::table
             .inner_join(users::table)
-            .filter(Self::with_id(id))
-            .get_result::<(Article, User)>(conn)?;
+            .filter(Self::with_id(id));
+        let result = t.get_result::<(Article, User)>(conn)?;
         Ok(result)
     }
 
@@ -138,21 +132,20 @@ impl Article {
         user_id: &Uuid,
     ) -> Result<bool, AppError> {
         use crate::schema::favorites;
-        let count = favorites::table
+        let t = favorites::table
             .select(diesel::dsl::count(favorites::id))
             .filter(Favorite::with_article_id(&self.id))
-            .filter(Favorite::with_user_id(user_id))
-            .first::<i64>(conn)?;
-
+            .filter(Favorite::with_user_id(user_id));
+        let count = t.first::<i64>(conn)?;
         Ok(count >= 1)
     }
 
     pub fn fetch_favorites_count(&self, conn: &mut PgConnection) -> Result<i64, AppError> {
         use crate::schema::favorites;
-        let favorites_count = favorites::table
+        let t = favorites::table
             .filter(Favorite::with_article_id(&self.id))
-            .select(diesel::dsl::count(favorites::created_at))
-            .first::<i64>(conn)?;
+            .select(diesel::dsl::count(favorites::created_at));
+        let favorites_count = t.first::<i64>(conn)?;
         Ok(favorites_count)
     }
 }

--- a/src/app/article/service.rs
+++ b/src/app/article/service.rs
@@ -291,7 +291,7 @@ pub fn fetch_following_articles(
                 .collect::<Vec<_>>();
 
             let list = follows::table
-                .filter(follows::follower_id.eq(params.current_user.id))
+                .filter(Follow::with_follower(&params.current_user.id))
                 .filter(follows::followee_id.eq_any(user_ids_list))
                 .get_results::<Follow>(conn)?;
 

--- a/src/app/article/service.rs
+++ b/src/app/article/service.rs
@@ -371,7 +371,7 @@ pub fn update_article(
         },
     )?;
 
-    let tag_list = Tag::fetch_by_article_id(conn, article.id)?;
+    let tag_list = Tag::fetch_by_article_id(conn, &article.id)?;
 
     let profile = params
         .current_user

--- a/src/app/article/service.rs
+++ b/src/app/article/service.rs
@@ -90,7 +90,7 @@ pub fn fetch_articles_list(
         let mut query = articles::table.inner_join(users::table).into_boxed();
 
         if let Some(tag_name) = &params.tag {
-            let ids = Tag::fetch_ids_by_name(conn, tag_name)
+            let ids = Tag::fetch_article_ids_by_name(conn, tag_name)
                 .expect("could not fetch tagged article ids."); // TODO: use ? or error handling
             query = query.filter(articles::id.eq_any(ids));
         }
@@ -119,7 +119,7 @@ pub fn fetch_articles_list(
             let mut query = articles::table.inner_join(users::table).into_boxed();
 
             if let Some(tag_name) = &params.tag {
-                let ids = Tag::fetch_ids_by_name(conn, tag_name)
+                let ids = Tag::fetch_article_ids_by_name(conn, tag_name)
                     .expect("could not fetch tagged article ids."); // TODO: use ? or error handling
                 query = query.filter(articles::id.eq_any(ids));
             }

--- a/src/app/comment/model.rs
+++ b/src/app/comment/model.rs
@@ -30,11 +30,11 @@ impl Comment {
     }
 
     pub fn delete(conn: &mut PgConnection, params: &DeleteComment) -> Result<(), AppError> {
-        diesel::delete(comments::table)
+        let t = comments::table
             .filter(comments::id.eq(params.comment_id))
             .filter(comments::author_id.eq(params.author_id))
-            .filter(comments::article_id.eq(params.article_id))
-            .execute(conn)?;
+            .filter(comments::article_id.eq(params.article_id));
+        diesel::delete(t).execute(conn)?;
         Ok(())
     }
 }

--- a/src/app/comment/model.rs
+++ b/src/app/comment/model.rs
@@ -3,6 +3,7 @@ use crate::app::user::model::User;
 use crate::error::AppError;
 use crate::schema::comments;
 use chrono::NaiveDateTime;
+use diesel::dsl::Eq;
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -21,6 +22,22 @@ pub struct Comment {
     pub updated_at: NaiveDateTime,
 }
 
+type WithId<T> = Eq<comments::id, T>;
+type WithAuthor<T> = Eq<comments::author_id, T>;
+type WithArticle<T> = Eq<comments::article_id, T>;
+
+impl Comment {
+    fn with_id(id: &Uuid) -> WithId<&Uuid> {
+        comments::id.eq(id)
+    }
+    fn with_author(author_id: &Uuid) -> WithAuthor<&Uuid> {
+        comments::author_id.eq(author_id)
+    }
+    fn with_article(article_id: &Uuid) -> WithArticle<&Uuid> {
+        comments::article_id.eq(article_id)
+    }
+}
+
 impl Comment {
     pub fn create(conn: &mut PgConnection, record: &CreateComment) -> Result<Self, AppError> {
         let new_comment = diesel::insert_into(comments::table)
@@ -31,9 +48,9 @@ impl Comment {
 
     pub fn delete(conn: &mut PgConnection, params: &DeleteComment) -> Result<(), AppError> {
         let t = comments::table
-            .filter(comments::id.eq(params.comment_id))
-            .filter(comments::author_id.eq(params.author_id))
-            .filter(comments::article_id.eq(params.article_id));
+            .filter(Self::with_id(&params.comment_id))
+            .filter(Self::with_author(&params.author_id))
+            .filter(Self::with_article(&params.article_id));
         diesel::delete(t).execute(conn)?;
         Ok(())
     }

--- a/src/app/favorite/model.rs
+++ b/src/app/favorite/model.rs
@@ -60,11 +60,11 @@ impl Favorite {
         username: &str,
     ) -> Result<Vec<Uuid>, AppError> {
         use crate::schema::users;
-        let ids = favorites::table
+        let t = favorites::table
             .inner_join(users::table)
             .filter(User::with_username(username))
-            .select(favorites::article_id)
-            .load::<Uuid>(conn)?;
+            .select(favorites::article_id);
+        let ids = t.load::<Uuid>(conn)?;
         Ok(ids)
     }
 }

--- a/src/app/favorite/model.rs
+++ b/src/app/favorite/model.rs
@@ -51,10 +51,10 @@ impl Favorite {
             article_id,
         }: &DeleteFavorite,
     ) -> Result<usize, AppError> {
-        let item = diesel::delete(favorites::table)
+        let t = favorites::table
             .filter(favorites::user_id.eq_all(user_id))
-            .filter(favorites::article_id.eq_all(article_id))
-            .execute(conn)?;
+            .filter(favorites::article_id.eq_all(article_id));
+        let item = diesel::delete(t).execute(conn)?;
         Ok(item)
     }
 

--- a/src/app/favorite/model.rs
+++ b/src/app/favorite/model.rs
@@ -3,7 +3,7 @@ use crate::app::user::model::User;
 use crate::error::AppError;
 use crate::schema::favorites;
 use chrono::NaiveDateTime;
-use diesel::dsl::{AsSelect, Eq, Filter, Select};
+use diesel::dsl::Eq;
 use diesel::*;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -20,11 +20,8 @@ pub struct Favorite {
     pub updated_at: NaiveDateTime,
 }
 
-// type All<DB> = Select<users::table, AsSelect<User, DB>>;
 type WithUserId<T> = Eq<favorites::user_id, T>;
 type WithArticleId<T> = Eq<favorites::article_id, T>;
-// type ByUserId<DB, T> = Filter<All<DB>, WithUserId<T>>;
-// type ByArticleId<DB, T> = Filter<All<DB>, WithArticleId<T>>;
 
 impl Favorite {
     pub fn with_user_id(user_id: &Uuid) -> WithUserId<&Uuid> {
@@ -52,8 +49,8 @@ impl Favorite {
         }: &DeleteFavorite,
     ) -> Result<usize, AppError> {
         let t = favorites::table
-            .filter(favorites::user_id.eq_all(user_id))
-            .filter(favorites::article_id.eq_all(article_id));
+            .filter(Self::with_user_id(user_id))
+            .filter(Self::with_article_id(article_id));
         let item = diesel::delete(t).execute(conn)?;
         Ok(item)
     }

--- a/src/app/follow/model.rs
+++ b/src/app/follow/model.rs
@@ -2,6 +2,7 @@ use crate::app::user::model::User;
 use crate::error::AppError;
 use crate::schema::follows;
 use chrono::NaiveDateTime;
+use diesel::dsl::{AsSelect, Eq, Filter, Select};
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -17,6 +18,24 @@ pub struct Follow {
     pub updated_at: NaiveDateTime,
 }
 
+type WithFollowee<T> = Eq<follows::followee_id, T>;
+type WithFollower<T> = Eq<follows::follower_id, T>;
+
+impl Follow {
+    pub fn with_followee(followee_id: &Uuid) -> WithFollowee<&Uuid> {
+        follows::followee_id.eq(followee_id)
+    }
+
+    pub fn with_follower(follower_id: &Uuid) -> WithFollower<&Uuid> {
+        follows::follower_id.eq(follower_id)
+    }
+    // fn by_followee_and_follower(followee_id: &Uuid, follower_id: &Uuid) -> Filter<Source,  {
+    //     let t = follows::table;
+    //     t.filter(follows::followee_id.eq(followee_id))
+    //         .filter(follows::follower_id.eq(follower_id))
+    // }
+}
+
 impl Follow {
     pub fn create(conn: &mut PgConnection, params: &CreateFollow) -> Result<(), AppError> {
         diesel::insert_into(follows::table)
@@ -26,12 +45,10 @@ impl Follow {
     }
 
     pub fn delete(conn: &mut PgConnection, params: &DeleteFollow) -> Result<(), AppError> {
-        diesel::delete(
-            follows::table
-                .filter(follows::followee_id.eq(params.followee_id))
-                .filter(follows::follower_id.eq(params.follower_id)),
-        )
-        .execute(conn)?;
+        let t = follows::table
+            .filter(Follow::with_followee(&params.followee_id))
+            .filter(Follow::with_follower(&params.follower_id));
+        diesel::delete(t).execute(conn)?;
         Ok(())
     }
 
@@ -40,7 +57,7 @@ impl Follow {
         follower_id: &Uuid,
     ) -> Result<Vec<Uuid>, AppError> {
         let result = follows::table
-            .filter(follows::follower_id.eq(follower_id))
+            .filter(Follow::with_follower(follower_id))
             .select(follows::followee_id)
             .get_results::<Uuid>(conn)?;
         Ok(result)

--- a/src/app/follow/model.rs
+++ b/src/app/follow/model.rs
@@ -2,7 +2,7 @@ use crate::app::user::model::User;
 use crate::error::AppError;
 use crate::schema::follows;
 use chrono::NaiveDateTime;
-use diesel::dsl::{AsSelect, Eq, Filter, Select};
+use diesel::dsl::Eq;
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -29,11 +29,6 @@ impl Follow {
     pub fn with_follower(follower_id: &Uuid) -> WithFollower<&Uuid> {
         follows::follower_id.eq(follower_id)
     }
-    // fn by_followee_and_follower(followee_id: &Uuid, follower_id: &Uuid) -> Filter<Source,  {
-    //     let t = follows::table;
-    //     t.filter(follows::followee_id.eq(followee_id))
-    //         .filter(follows::follower_id.eq(follower_id))
-    // }
 }
 
 impl Follow {
@@ -56,10 +51,10 @@ impl Follow {
         conn: &mut PgConnection,
         follower_id: &Uuid,
     ) -> Result<Vec<Uuid>, AppError> {
-        let result = follows::table
+        let t = follows::table
             .filter(Follow::with_follower(follower_id))
-            .select(follows::followee_id)
-            .get_results::<Uuid>(conn)?;
+            .select(follows::followee_id);
+        let result = t.get_results::<Uuid>(conn)?;
         Ok(result)
     }
 }

--- a/src/app/tag/model.rs
+++ b/src/app/tag/model.rs
@@ -39,29 +39,29 @@ type WithArticleId<T> = Eq<tags::article_id, T>;
 type ByArticleId<T, DB> = Filter<All<DB>, WithArticleId<T>>;
 
 impl Tag {
-    pub fn all<DB>() -> All<DB>
+    fn all<DB>() -> All<DB>
     where
         DB: Backend,
     {
         tags::table.select(Tag::as_select())
     }
 
-    pub fn with_name(name: &str) -> WithName<&str> {
+    fn with_name(name: &str) -> WithName<&str> {
         tags::name.eq(name)
     }
 
-    pub fn by_name<DB>(name: &str) -> ByName<&str, DB>
+    fn by_name<DB>(name: &str) -> ByName<&str, DB>
     where
         DB: Backend,
     {
         Self::all().filter(Self::with_name(name))
     }
 
-    pub fn with_article_id(article_id: &Uuid) -> WithArticleId<&Uuid> {
+    fn with_article_id(article_id: &Uuid) -> WithArticleId<&Uuid> {
         tags::article_id.eq(article_id)
     }
 
-    pub fn by_article_id<DB>(article_id: &Uuid) -> ByArticleId<&Uuid, DB>
+    fn by_article_id<DB>(article_id: &Uuid) -> ByArticleId<&Uuid, DB>
     where
         DB: Backend,
     {

--- a/src/app/tag/model.rs
+++ b/src/app/tag/model.rs
@@ -72,7 +72,8 @@ impl Tag {
         conn: &mut PgConnection,
         article_id: &Uuid,
     ) -> Result<Vec<Self>, AppError> {
-        let list = Self::by_article_id(article_id).get_results::<Self>(conn)?;
+        let t = Self::by_article_id(article_id);
+        let list = t.get_results::<Self>(conn)?;
         Ok(list)
     }
 
@@ -85,7 +86,8 @@ impl Tag {
         conn: &mut PgConnection,
         tag_name: &str,
     ) -> Result<Vec<Uuid>, AppError> {
-        let article_ids = Self::by_name(tag_name)
+        let t = Self::by_name(tag_name);
+        let article_ids = t
             .load::<Tag>(conn)?
             .iter()
             .map(|tag| tag.article_id)

--- a/src/app/tag/model.rs
+++ b/src/app/tag/model.rs
@@ -134,15 +134,16 @@ impl Tag {
         Ok(list)
     }
 
-    pub fn fetch_ids_by_name(
+    pub fn fetch_article_ids_by_name(
         conn: &mut PgConnection,
         tag_name: &str,
     ) -> Result<Vec<Uuid>, AppError> {
-        let ids = tags::table
-            .filter(Self::with_name(tag_name))
-            .select(tags::article_id)
-            .load::<Uuid>(conn)?;
-        Ok(ids)
+        let article_ids = Self::by_name(tag_name)
+            .load::<Tag>(conn)?
+            .iter()
+            .map(|tag| tag.article_id)
+            .collect();
+        Ok(article_ids)
     }
 
     pub fn create_list(

--- a/src/app/tag/model.rs
+++ b/src/app/tag/model.rs
@@ -154,7 +154,7 @@ impl Tag {
         //     Self::all().filter(Self::with_name(name))
 
         let ids = tags::table
-            .select::<AllColumns>(ALL_COLUMNS)
+            // .select::<AllColumns>(ALL_COLUMNS)
             .filter(Tag::with_name(tag_name))
             .select(tags::article_id)
             .load::<Uuid>(conn)?;

--- a/src/app/tag/model.rs
+++ b/src/app/tag/model.rs
@@ -3,37 +3,12 @@ use crate::error::AppError;
 use crate::schema::tags;
 use chrono::NaiveDateTime;
 use diesel::backend::Backend;
-// use diesel::dsl::Eq;
-// use diesel::dsl::{AsSelect, SqlTypeOf};
-// use diesel::expression::{AsExpression, Expression};
-// use diesel::pg::Pg;
-use diesel::dsl::Eq;
-use diesel::dsl::Filter;
-use diesel::dsl::{AsSelect, Select};
-use diesel::expression::AsExpression;
+use diesel::dsl::{AsSelect, Eq, Filter, Select};
 use diesel::pg::PgConnection;
-// use diesel::prelude::sql_function;
-use diesel::sql_types;
 use diesel::Insertable;
 use diesel::*;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-
-// type AllColumns = (
-//     tags::id,
-//     tags::article_id,
-//     tags::name,
-//     tags::created_at,
-//     tags::updated_at,
-// );
-
-// pub const ALL_COLUMNS: AllColumns = (
-//     tags::id,
-//     tags::article_id,
-//     tags::name,
-//     tags::created_at,
-//     tags::updated_at,
-// );
 
 #[derive(
     Identifiable,
@@ -56,39 +31,14 @@ pub struct Tag {
     pub updated_at: NaiveDateTime,
 }
 
-// General
-// type SqlType = SqlTypeOf<AsSelect<Tag, Pg>>;
-// type BoxedQuery<'a> = tags::BoxedQuery<'a, Pg, SqlType>;
-
 // Tags
 type All<DB> = Select<tags::table, AsSelect<Tag, DB>>;
 type WithName<T> = Eq<tags::name, T>;
 type ByName<T, DB> = Filter<All<DB>, WithName<T>>;
-// type WithArticleId<'a> = Eq<tags::article_id, &'a Uuid>;
-// type ByArticleId<'a> = Filter<Tag, WithArticleId<'a>>;
 type WithArticleId<T> = Eq<tags::article_id, T>;
 type ByArticleId<T, DB> = Filter<All<DB>, WithArticleId<T>>;
 
 impl Tag {
-    // pub fn with_name<T>(name: T) -> WithName<'static>
-    // where
-    //     T: AsExpression<sql_types::Text>,
-    // {
-    //     canon_name(tags::name).eq(canon_name(name))
-    // }
-    // fn by_article_id<'a, T>(article_id: T) -> BoxedQuery<'a>
-    // where
-    //     T: AsExpression<sql_types::Uuid>,
-    //     T::Expression: BoxableExpression<tags::table, Pg>,
-    // {
-    //     tags::table.filter(with_article_id(article_id))
-    // }
-
-    // fn select_article_ids() -> BoxedQuery<'static> {
-    //     // tags::table.select(Tag::as_select()).into_boxed()
-    //     tags::table.select(tags::article_id).into_boxed()
-    // }
-
     pub fn all<DB>() -> All<DB>
     where
         DB: Backend,

--- a/src/app/tag/model.rs
+++ b/src/app/tag/model.rs
@@ -63,12 +63,12 @@ sql_function!(fn canon_name(x: sql_types::Text) -> sql_types::Text);
 // type BoxedQuery<'a> = tags::BoxedQuery<'a, Pg, SqlType>;
 
 // Tags
-type CanonName<T> = canon_name::HelperType<T>;
+// type CanonName<T> = canon_name::HelperType<T>;
 // type CanonArticleId<T> = canon_id::HelperType<T>;
 type All<DB> = Select<tags::table, AsSelect<Tag, DB>>;
 // type All<Columns> = Select<tags::table, AsSelect<Tag, Columns>>;
-type WithName<T> = Eq<CanonName<tags::name>, CanonName<T>>;
-type ByName<T, DB> = diesel::dsl::Filter<All<DB>, WithName<T>>;
+type WithName<T> = Eq<tags::name, T>;
+// type ByName<T, DB> = diesel::dsl::Filter<All<DB>, WithName<T>>;
 // type WithArticleId<'a> = Eq<CanonArticleId<tags::article_id>, CanonArticleId<&'a Uuid>>;
 // type ByArticleId<'a> = Filter<All, WithArticleId<'a>>;
 
@@ -112,7 +112,8 @@ impl Tag {
     where
         T: AsExpression<sql_types::Text>,
     {
-        canon_name(tags::name).eq(canon_name(name))
+        tags::name.eq(name)
+        // canon_name(tags::name).eq(canon_name(name))
     }
 
     // pub fn by_name<T, DB>(name: T) -> ByName<T, DB>

--- a/src/app/tag/model.rs
+++ b/src/app/tag/model.rs
@@ -43,7 +43,7 @@ pub struct Tag {
 }
 
 sql_function!(fn canon_name(x: sql_types::Text) -> sql_types::Text);
-sql_function!(fn canon_id(x: sql_types::Uuid) -> sql_types::Uuid);
+// sql_function!(fn canon_id(x: sql_types::Uuid) -> sql_types::Uuid);
 
 // General
 // type SqlType = SqlTypeOf<AsSelect<Tag, Pg>>;
@@ -51,12 +51,12 @@ sql_function!(fn canon_id(x: sql_types::Uuid) -> sql_types::Uuid);
 
 // Tags
 type CanonName<T> = canon_name::HelperType<T>;
-type CanonArticleId<T> = canon_id::HelperType<T>;
+// type CanonArticleId<T> = canon_id::HelperType<T>;
 type All = Select<tags::table, AllColumns>;
 type WithName<'a> = Eq<CanonName<tags::name>, CanonName<&'a str>>;
 type ByName<'a> = Filter<All, WithName<'a>>;
-type WithArticleId<'a> = Eq<CanonArticleId<tags::article_id>, CanonArticleId<&'a Uuid>>;
-type ByArticleId<'a> = Filter<All, WithArticleId<'a>>;
+// type WithArticleId<'a> = Eq<CanonArticleId<tags::article_id>, CanonArticleId<&'a Uuid>>;
+// type ByArticleId<'a> = Filter<All, WithArticleId<'a>>;
 
 impl Tag {
     // pub fn with_name<T>(name: T) -> WithName<'static>
@@ -99,19 +99,22 @@ impl Tag {
         Self::all().filter(Self::with_name(name))
     }
 
-    pub fn with_article_id(article_id: &Uuid) -> WithArticleId<'_> {
-        canon_id(tags::article_id).eq(canon_id(article_id))
-    }
+    // pub fn with_article_id(article_id: &Uuid) -> WithArticleId<'_> {
+    //     canon_id(tags::article_id).eq(canon_id(article_id))
+    // }
 
-    pub fn by_article_id(article_id: &Uuid) -> ByArticleId<'_> {
-        Self::all().filter(Self::with_article_id(article_id))
-    }
+    // pub fn by_article_id(article_id: &Uuid) -> ByArticleId<'_> {
+    //     Self::all().filter(Self::with_article_id(article_id))
+    // }
 
     pub fn fetch_by_article_id(
         conn: &mut PgConnection,
         article_id: Uuid,
     ) -> Result<Vec<Self>, AppError> {
-        let list = Self::by_article_id(&article_id).get_results::<Self>(conn)?;
+        // let list = Self::by_article_id(&article_id).get_results::<Self>(conn)?;
+        let list = tags::table
+            .filter(tags::article_id.eq(article_id))
+            .get_results::<Self>(conn)?;
         Ok(list)
     }
 

--- a/src/app/tag/model.rs
+++ b/src/app/tag/model.rs
@@ -8,7 +8,7 @@ use diesel::backend::Backend;
 // use diesel::expression::{AsExpression, Expression};
 // use diesel::pg::Pg;
 use diesel::dsl::Eq;
-// use diesel::dsl::Filter;
+use diesel::dsl::Filter;
 use diesel::dsl::{AsSelect, Select};
 use diesel::expression::AsExpression;
 use diesel::pg::PgConnection;
@@ -69,7 +69,7 @@ pub struct Tag {
 type All<DB> = Select<tags::table, AsSelect<Tag, DB>>;
 // type All<Columns> = Select<tags::table, AsSelect<Tag, Columns>>;
 type WithName<T> = Eq<tags::name, T>;
-// type ByName<T, DB> = Filter<All<DB>, WithName<T>>;
+type ByName<T, DB> = Filter<All<DB>, WithName<T>>;
 type WithArticleId<'a> = Eq<tags::article_id, &'a Uuid>;
 // type ByArticleId<'a> = Filter<All, WithArticleId<'a>>;
 
@@ -93,15 +93,6 @@ impl Tag {
     //     tags::table.select(tags::article_id).into_boxed()
     // }
 
-    // fn by_name<'a, T>(name: T) -> BoxedQuery<'a>
-    // where
-    //     T: AsExpression<sql_types::Text>,
-    //     T::Expression: BoxableExpression<tags::table, Pg>,
-    // {
-    //     tags::table.filter(with_name(name))
-    //     // Self::select_article_ids().filter(with_name(name))
-    // }
-
     pub fn all<DB>() -> All<DB>
     where
         DB: Backend,
@@ -109,21 +100,16 @@ impl Tag {
         tags::table.select(Tag::as_select())
     }
 
-    pub fn with_name<T>(name: T) -> WithName<T>
-    where
-        T: AsExpression<sql_types::Text>,
-    {
+    pub fn with_name(name: &str) -> WithName<&str> {
         tags::name.eq(name)
     }
 
-    // pub fn by_name<T, DB>(name: T) -> ByName<T, DB>
-    // where
-    //     T: AsExpression<sql_types::Text>,
-    //     DB: Backend,
-    // {
-    //     tags::table.filter(Self::with_name(name))
-    //     // Self::all().filter(Self::with_name(name))
-    // }
+    pub fn by_name<DB>(name: &str) -> ByName<&str, DB>
+    where
+        DB: Backend,
+    {
+        Self::all().filter(Self::with_name(name))
+    }
 
     pub fn with_article_id(article_id: &Uuid) -> WithArticleId<'_> {
         tags::article_id.eq(article_id)

--- a/src/app/tag/model.rs
+++ b/src/app/tag/model.rs
@@ -6,6 +6,7 @@ use chrono::NaiveDateTime;
 // use diesel::dsl::{AsSelect, SqlTypeOf};
 // use diesel::expression::{AsExpression, Expression};
 // use diesel::pg::Pg;
+use diesel::dsl::{Eq, Filter, Select};
 use diesel::pg::PgConnection;
 use diesel::prelude::sql_function;
 use diesel::sql_types;
@@ -51,12 +52,11 @@ sql_function!(fn canon_id(x: sql_types::Uuid) -> sql_types::Uuid);
 // Tags
 type CanonName<T> = canon_name::HelperType<T>;
 type CanonArticleId<T> = canon_id::HelperType<T>;
-type All = diesel::dsl::Select<tags::table, AllColumns>;
-type WithName<'a> = diesel::dsl::Eq<CanonName<tags::name>, CanonName<&'a str>>;
-type ByName<'a> = diesel::dsl::Filter<All, WithName<'a>>;
-type WithArticleId<'a> =
-    diesel::dsl::Eq<CanonArticleId<tags::article_id>, CanonArticleId<&'a Uuid>>;
-type ByArticleId<'a> = diesel::dsl::Filter<All, WithArticleId<'a>>;
+type All = Select<tags::table, AllColumns>;
+type WithName<'a> = Eq<CanonName<tags::name>, CanonName<&'a str>>;
+type ByName<'a> = Filter<All, WithName<'a>>;
+type WithArticleId<'a> = Eq<CanonArticleId<tags::article_id>, CanonArticleId<&'a Uuid>>;
+type ByArticleId<'a> = Filter<All, WithArticleId<'a>>;
 
 impl Tag {
     // pub fn with_name<T>(name: T) -> WithName<'static>

--- a/src/app/user/model.rs
+++ b/src/app/user/model.rs
@@ -41,7 +41,7 @@ impl User {
         users::table.select(User::as_select())
     }
 
-    fn with_username(username: &str) -> WithUsername<&str> {
+    pub fn with_username(username: &str) -> WithUsername<&str> {
         users::username.eq(username)
     }
 

--- a/src/app/user/model.rs
+++ b/src/app/user/model.rs
@@ -162,8 +162,8 @@ impl User {
     pub fn is_following(&self, conn: &mut PgConnection, followee_id: &Uuid) -> bool {
         use crate::schema::follows;
         let follow = follows::table
-            .filter(follows::followee_id.eq(followee_id))
-            .filter(follows::follower_id.eq(self.id))
+            .filter(Follow::with_followee(followee_id))
+            .filter(Follow::with_follower(&self.id))
             .get_result::<Follow>(conn);
         follow.is_ok()
     }

--- a/src/app/user/model.rs
+++ b/src/app/user/model.rs
@@ -112,7 +112,7 @@ impl User {
         user_id: Uuid,
         changeset: UpdateUser,
     ) -> Result<Self, AppError> {
-        let target = users::table.filter(users::id.eq(user_id));
+        let target = users::table.find(user_id);
         let user = diesel::update(target)
             .set(changeset)
             .get_result::<User>(conn)?;

--- a/src/app/user/model.rs
+++ b/src/app/user/model.rs
@@ -1,3 +1,4 @@
+use crate::app::favorite::model::Favorite;
 use crate::app::follow::model::{CreateFollow, DeleteFollow, Follow};
 use crate::app::profile::model::Profile;
 use crate::error::AppError;
@@ -187,7 +188,7 @@ impl User {
     ) -> Result<Vec<Uuid>, AppError> {
         use crate::schema::favorites;
         let t = favorites::table
-            .filter(favorites::user_id.eq(self.id))
+            .filter(Favorite::with_user_id(&self.id))
             .select(favorites::article_id);
         let favorited_article_ids = t.get_results::<Uuid>(conn)?;
         Ok(favorited_article_ids)

--- a/src/app/user/model.rs
+++ b/src/app/user/model.rs
@@ -93,14 +93,16 @@ impl User {
         email: &str,
         naive_password: &str,
     ) -> Result<(User, Token), AppError> {
-        let user = Self::by_email(email).limit(1).first::<User>(conn)?;
+        let t = Self::by_email(email).limit(1);
+        let user = t.first::<User>(conn)?;
         hasher::verify(naive_password, &user.password)?;
         let token = user.generate_token()?;
         Ok((user, token))
     }
 
     pub fn find(conn: &mut PgConnection, id: Uuid) -> Result<Self, AppError> {
-        let user = users::table.find(id).first(conn)?;
+        let t = users::table.find(id);
+        let user = t.first(conn)?;
         Ok(user)
     }
 
@@ -117,12 +119,14 @@ impl User {
     }
 
     pub fn find_by_username(conn: &mut PgConnection, username: &str) -> Result<Self, AppError> {
-        let user = Self::by_username(username).limit(1).first::<User>(conn)?;
+        let t = Self::by_username(username).limit(1);
+        let user = t.first::<User>(conn)?;
         Ok(user)
     }
 
     pub fn follow(&self, conn: &mut PgConnection, username: &str) -> Result<Profile, AppError> {
-        let followee = Self::by_username(username).first::<User>(conn)?;
+        let t = Self::by_username(username);
+        let followee = t.first::<User>(conn)?;
 
         Follow::create(
             conn,
@@ -141,7 +145,8 @@ impl User {
     }
 
     pub fn unfollow(&self, conn: &mut PgConnection, username: &str) -> Result<Profile, AppError> {
-        let followee = Self::by_username(username).first::<User>(conn)?;
+        let t = Self::by_username(username);
+        let followee = t.first::<User>(conn)?;
 
         Follow::delete(
             conn,
@@ -161,10 +166,10 @@ impl User {
 
     pub fn is_following(&self, conn: &mut PgConnection, followee_id: &Uuid) -> bool {
         use crate::schema::follows;
-        let follow = follows::table
+        let t = follows::table
             .filter(Follow::with_followee(followee_id))
-            .filter(Follow::with_follower(&self.id))
-            .get_result::<Follow>(conn);
+            .filter(Follow::with_follower(&self.id));
+        let follow = t.get_result::<Follow>(conn);
         follow.is_ok()
     }
 }
@@ -181,10 +186,10 @@ impl User {
         conn: &mut PgConnection,
     ) -> Result<Vec<Uuid>, AppError> {
         use crate::schema::favorites;
-        let favorited_article_ids = favorites::table
+        let t = favorites::table
             .filter(favorites::user_id.eq(self.id))
-            .select(favorites::article_id)
-            .get_results::<Uuid>(conn)?;
+            .select(favorites::article_id);
+        let favorited_article_ids = t.get_results::<Uuid>(conn)?;
         Ok(favorited_article_ids)
     }
 


### PR DESCRIPTION
## Issues
Now, helper functions take `connection` as arguments for connecting to the database but it prevents it from being reusable functions.

This PR almost separates logic into query (not including conn) and execution (including conn).